### PR TITLE
feat: add upcoming events section on homepage

### DIFF
--- a/app/blueprints/events.py
+++ b/app/blueprints/events.py
@@ -40,17 +40,31 @@ for event in events:
 
 @events_bp.route("/events/<string:event_slug>")
 def event_detail(event_slug):
+    from datetime import datetime
     decoded_name = decode_slug(event_slug)
     event = next((e for e in events if e["name"] == decoded_name), None)
     eventname = event["name"] if event else None
     if not event:
         return render_template("event_detail_404.html", events=events)
+    is_upcoming = False
+    try:
+        date_str = event["date"].strip()
+        if " - " in date_str:
+            date_str = date_str.split(" - ")[0].strip()
+            if len(date_str.split()) == 2:
+                year = event["date"].strip().split(",")[-1].strip()
+                date_str = date_str + ", " + year
+        event_date = datetime.strptime(date_str, "%B %d, %Y")
+        is_upcoming = event_date > datetime.now()
+    except ValueError:
+        pass
     return render_template(
         "event_detail.html",
         event=event,
         events=events,
         event_slug=event_slug,
         eventname=eventname,
+        is_upcoming=is_upcoming,
     )
 
 

--- a/app/blueprints/home.py
+++ b/app/blueprints/home.py
@@ -2,6 +2,7 @@
 from flask import Blueprint, render_template, send_from_directory, redirect, url_for
 from app.data.events import events
 from app.data.stories import stories
+from datetime import datetime
 
 # Define the blueprint
 home_bp = Blueprint("home", __name__, template_folder="../templates")
@@ -30,9 +31,28 @@ images_2 = [
 
 @home_bp.route("/")
 def home():
+    now = datetime.now()
+    upcoming_events = []
+    past_events = []
+    for event in events:
+        try:
+            date_str = event["date"].strip()
+            if " - " in date_str:
+                date_str = date_str.split(" - ")[0].strip()
+                if len(date_str.split()) == 2:
+                    year = event["date"].strip().split(",")[-1].strip()
+                    date_str = date_str + ", " + year
+            event_date = datetime.strptime(date_str, "%B %d, %Y")
+            if event_date > now:
+                upcoming_events.append(event)
+            else:
+                past_events.append(event)
+        except ValueError:
+            past_events.append(event)
     return render_template(
         "home.html",
-        events=events[:6],
+        events=past_events[:6],
+        upcoming_events=upcoming_events,
         images=images,
         images_2=images_2,
         stories=stories[:4],

--- a/app/data/events.py
+++ b/app/data/events.py
@@ -1,15 +1,4 @@
 events = [
-
-    {
-    "name": "Demo Upcoming Event",
-    "description": "This is a demo upcoming event to showcase the new upcoming events section on the homepage. Stay tuned for more details!",
-    "date": "August 27, 2026",
-    "moredetails": "https://links.ioit.acm.org/haFXk",
-    "image_url": "/static/img/competitions/banner/bbd.jpeg",
-    "instagram_link": "",
-    "facebook_link": "",
-    "topics": [],
-},
         {
             "name": "Ethical Hacking Workshop",
             "description": "This beginner-friendly workshop introduces students to the fundamentals of cybersecurity and ethical hacking. Participants explore how attackers think and how ethical hackers defend systems, covering core concepts across web security, malware, cryptography, cloud security, and digital forensics, along with insights into cybersecurity career paths.",

--- a/app/data/events.py
+++ b/app/data/events.py
@@ -3,6 +3,7 @@ events = [
             "name": "Ethical Hacking Workshop",
             "description": "This beginner-friendly workshop introduces students to the fundamentals of cybersecurity and ethical hacking. Participants explore how attackers think and how ethical hackers defend systems, covering core concepts across web security, malware, cryptography, cloud security, and digital forensics, along with insights into cybersecurity career paths.",
             "date": "August 4, 2026",
+            "registration_link": "",
             "moredetails": "Exclusively for Second Year students of IT, Computer Engineering, and AI & DS. Timing: 10:30 AM - 4:00 PM.",
             "image_url": "",
             "instagram_link": "",

--- a/app/data/events.py
+++ b/app/data/events.py
@@ -1,4 +1,15 @@
 events = [
+
+    {
+    "name": "Demo Upcoming Event",
+    "description": "This is a demo upcoming event to showcase the new upcoming events section on the homepage. Stay tuned for more details!",
+    "date": "August 27, 2026",
+    "moredetails": "",
+    "image_url": "/static/img/competitions/banner/bbd.jpeg",
+    "instagram_link": "",
+    "facebook_link": "",
+    "topics": [],
+},
         {
             "name": "Ethical Hacking Workshop",
             "description": "This beginner-friendly workshop introduces students to the fundamentals of cybersecurity and ethical hacking. Participants explore how attackers think and how ethical hackers defend systems, covering core concepts across web security, malware, cryptography, cloud security, and digital forensics, along with insights into cybersecurity career paths.",

--- a/app/data/events.py
+++ b/app/data/events.py
@@ -4,7 +4,7 @@ events = [
     "name": "Demo Upcoming Event",
     "description": "This is a demo upcoming event to showcase the new upcoming events section on the homepage. Stay tuned for more details!",
     "date": "August 27, 2026",
-    "moredetails": "",
+    "moredetails": "https://links.ioit.acm.org/haFXk",
     "image_url": "/static/img/competitions/banner/bbd.jpeg",
     "instagram_link": "",
     "facebook_link": "",

--- a/app/templates/competitions/avaliable-contests.html
+++ b/app/templates/competitions/avaliable-contests.html
@@ -120,15 +120,5 @@
 
 
 
-<section class="my-20">
-  <h2 class="text-2xl font-semibold mb-6 text-gray-800 sm:text-3xl">Coming Soon</h2>
-  <div>
-    <h3 class="text-lg sm:text-xl font-semibold mb-2">
-      Future Events & Competitions
-    </h3>
-    <p class="text-sm sm:text-base leading-relaxed">
-      Stay tuned for more exciting events and competitions. We have a lot in store!
-    </p>
-  </div>
-</section>
+
 

--- a/app/templates/event_detail.html
+++ b/app/templates/event_detail.html
@@ -52,8 +52,8 @@
                 Share Event
                 <i class="fas fa-share-square"></i>
             </button>
-            {% if event.moredetails and is_upcoming %}
-                <a href="{{ event.moredetails }}"
+            {% if event.registration_link and is_upcoming %}
+                <a href="{{ event.registration_link }}"
                 target="_blank"
                 class="px-3 py-2 text-sm bg-yellow-400 hover:bg-yellow-500 text-gray-900 font-semibold rounded-lg shadow-md flex items-center gap-2 transition-all duration-200 ease-in-out">
                     Register
@@ -65,6 +65,14 @@
                 Feedback Form
                 <i class="fas fa-arrow-up-right-from-square"></i>
             </a>
+            {% if event.moredetails %}
+                    <a href="{{ event.moredetails }}"
+                       target="_blank"
+                       class="px-3 py-2 text-sm bg-blue-600 text-white font-semibold rounded-lg shadow-md flex items-center gap-2 transition-all duration-200 ease-in-out hover:bg-blue-700">
+                        More Details
+                        <i class="fas fa-info-circle"></i>
+                    </a>
+                {% endif %}
             </div>
             <hr class="my-4 border-t-2 border-gray-300" />
             <!-- Social Media Links Section -->

--- a/app/templates/event_detail.html
+++ b/app/templates/event_detail.html
@@ -48,23 +48,23 @@
             </div>
             <div class="md:text-base text-xs my-5 flex justify-start items-center gap-4 flex-wrap">
                 <button id="sharebutton"
-                        class="px-3 py-2 text-sm bg-blue-500 text-white font-semibold rounded-lg shadow-md flex items-center gap-2 transition-all duration-200 ease-in-out hover:bg-blue-600">
-                    Share Event
-                    <i class="fas fa-share-square"></i>
-                </button>
-                <a href="/feedback?type=eventfeedback&event={{ event.name }}"
-                   class="px-3 py-2 text-sm bg-green-400 hover:bg-green-500 text-gray-900 font-semibold rounded-lg shadow-md flex items-center gap-2 transition-all duration-200 ease-in-out">
-                    Feedback Form
+                    class="px-3 py-2 text-sm bg-blue-500 text-white font-semibold rounded-lg shadow-md flex items-center gap-2 transition-all duration-200 ease-in-out hover:bg-blue-600">
+                Share Event
+                <i class="fas fa-share-square"></i>
+            </button>
+            {% if event.moredetails and is_upcoming %}
+                <a href="{{ event.moredetails }}"
+                target="_blank"
+                class="px-3 py-2 text-sm bg-yellow-400 hover:bg-yellow-500 text-gray-900 font-semibold rounded-lg shadow-md flex items-center gap-2 transition-all duration-200 ease-in-out">
+                    Register
                     <i class="fas fa-arrow-up-right-from-square"></i>
                 </a>
-                {% if event.moredetails %}
-                    <a href="{{ event.moredetails }}"
-                       target="_blank"
-                       class="px-3 py-2 text-sm bg-blue-600 text-white font-semibold rounded-lg shadow-md flex items-center gap-2 transition-all duration-200 ease-in-out hover:bg-blue-700">
-                        More Details
-                        <i class="fas fa-info-circle"></i>
-                    </a>
                 {% endif %}
+            <a href="/feedback?type=eventfeedback&event={{ event.name }}"
+            class="px-3 py-2 text-sm bg-green-400 hover:bg-green-500 text-gray-900 font-semibold rounded-lg shadow-md flex items-center gap-2 transition-all duration-200 ease-in-out">
+                Feedback Form
+                <i class="fas fa-arrow-up-right-from-square"></i>
+            </a>
             </div>
             <hr class="my-4 border-t-2 border-gray-300" />
             <!-- Social Media Links Section -->

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -281,8 +281,8 @@
                                class="text-sm bg-blue-600 hover:bg-blue-700 text-white font-semibold px-4 py-2 rounded-lg transition-all hover:no-underline">
                                 Learn More
                             </a>
-                            {% if event.moredetails %}
-                            <a href="{{ event.moredetails }}"
+                            {% if event.registration_link %}
+                            <a href="{{ event.registration_link }}"
                                target="_blank"
                                class="text-sm bg-green-400 hover:bg-green-500 text-gray-900 font-semibold px-4 py-2 rounded-lg transition-all hover:no-underline">
                                 Register

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -250,6 +250,52 @@
                 </div>
             </div>
         </section>
+        {% if upcoming_events %}
+        <section class="mt-16">
+            <div class="flex justify-between md:items-center mb-8 gap-3 md:gap-0 flex-col md:flex-row w-full">
+                <h2 class="text-3xl font-semibold text-gray-800">Upcoming Events</h2>
+                <a href="/events" class="text-blue-800 hover:text-blue-700 text-sm">View All Events</a>
+            </div>
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                {% for event in upcoming_events %}
+                <div class="bg-white rounded-xl shadow-md overflow-hidden border border-gray-200 group">
+                    <div class="overflow-hidden h-48">
+                        {% if event.image_url %}
+                        <img
+                            src="{{ event.image_url }}"
+                            alt="{{ event.name }}"
+                            class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-110"
+                        />
+                        {% else %}
+                        <div class="w-full h-full bg-gradient-to-br from-blue-600 to-blue-800 flex items-center justify-center transition-transform duration-300 group-hover:scale-110">
+                            <i class="fas fa-calendar-alt text-white text-5xl"></i>
+                        </div>
+                        {% endif %}
+                    </div>
+                    <div class="p-5">
+                        <p class="text-blue-600 text-sm font-semibold mb-1">{{ event.date }}</p>
+                        <h3 class="text-lg font-bold text-gray-800 mb-2">{{ event.name }}</h3>
+                        <p class="text-gray-600 text-sm line-clamp-3 mb-4">{{ event.description }}</p>
+                        <div class="flex gap-3 flex-wrap">
+                            <a href="{{ url_for('events.event_detail', event_slug=event.name) }}"
+                               class="text-sm bg-blue-600 hover:bg-blue-700 text-white font-semibold px-4 py-2 rounded-lg transition-all hover:no-underline">
+                                Learn More
+                            </a>
+                            {% if event.moredetails %}
+                            <a href="{{ event.moredetails }}"
+                               target="_blank"
+                               class="text-sm bg-green-400 hover:bg-green-500 text-gray-900 font-semibold px-4 py-2 rounded-lg transition-all hover:no-underline">
+                                Register
+                            </a>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+                {% endfor %}
+            </div>
+        </section>
+        {% endif %}
+
         {% include 'flagship_events.html' %}
         <div class="my-20">
             <div class="bg-white shadow-xl rounded-xl overflow-hidden flex flex-col sm:flex-row items-stretch">


### PR DESCRIPTION
Closes #34

## Changes
- Added upcoming events section above flagship events in `home.html`
- Filtered upcoming vs past events by date in `home.py`
- Past events correctly show only in Recent Events section
- Removed Coming Soon section from `avaliable-contests.html`

## Notes
- Events with future dates automatically appear in upcoming section
- Section is hidden when there are no upcoming events

## Testing
Tested locally at http://localhost:5001
<img width="1900" height="901" alt="image" src="https://github.com/user-attachments/assets/fe2e8e52-4105-41b7-b244-44841a91de1a" />
<img width="1907" height="1037" alt="image" src="https://github.com/user-attachments/assets/23242543-dbe3-4d05-bcc7-7eebf38719b5" />
