### PR TITLE
fix: moredetails field of Ethical Hacking workshop

### DIFF
--- a/app/data/events.py
+++ b/app/data/events.py
@@ -4,7 +4,7 @@ events = [
             "description": "This beginner-friendly workshop introduces students to the fundamentals of cybersecurity and ethical hacking. Participants explore how attackers think and how ethical hackers defend systems, covering core concepts across web security, malware, cryptography, cloud security, and digital forensics, along with insights into cybersecurity career paths.",
             "date": "August 4, 2026",
             "registration_link": "",
-            "moredetails": "Exclusively for Second Year students of IT, Computer Engineering, and AI & DS. Timing: 10:30 AM - 4:00 PM.",
+            "moredetails": "",
             "image_url": "",
             "instagram_link": "",
             "facebook_link": "",


### PR DESCRIPTION
The moredetails field for Ethical Hacking workshop event contained text instead of a url.